### PR TITLE
Add libvirt-python patches not yet included upstream

### DIFF
--- a/patches.python/0001-libvirtaio-add-more-debug-logging.patch
+++ b/patches.python/0001-libvirtaio-add-more-debug-logging.patch
@@ -1,0 +1,93 @@
+From 2b1e7047293cabffc019e30f8f45e6036b923379 Mon Sep 17 00:00:00 2001
+From: Wojtek Porczyk <woju@invisiblethingslab.com>
+Date: Thu, 24 Aug 2017 21:22:49 +0200
+Subject: [PATCH 1/2] libvirtaio: add more debug logging
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+This logging is helpful for tracing problems with unclosed connections
+and leaking file descriptors.
+
+Signed-off-by: Wojtek Porczyk <woju@invisiblethingslab.com
+---
+ libvirtaio.py | 29 +++++++++++++++++++++--------
+ 1 file changed, 21 insertions(+), 8 deletions(-)
+
+diff --git a/libvirtaio.py b/libvirtaio.py
+index 7c8c396..fc868bd 100644
+--- a/libvirtaio.py
++++ b/libvirtaio.py
+@@ -74,7 +74,7 @@ class Callback(object):
+     def close(self):
+         '''Schedule *ff* callback'''
+         self.impl.log.debug('callback %d close(), scheduling ff', self.iden)
+-        self.impl.schedule_ff_callback(self.opaque)
++        self.impl.schedule_ff_callback(self.iden, self.opaque)
+ 
+ #
+ # file descriptors
+@@ -284,9 +284,18 @@ class virEventAsyncIOImpl(object):
+             self._add_timeout, self._update_timeout, self._remove_timeout)
+         return self
+ 
+-    def schedule_ff_callback(self, opaque):
++    def schedule_ff_callback(self, iden, opaque):
+         '''Schedule a ff callback from one of the handles or timers'''
+-        self.loop.call_soon(libvirt.virEventInvokeFreeCallback, opaque)
++        ensure_future(self._ff_callback(iden, opaque), loop=self.loop)
++
++    @asyncio.coroutine
++    def _ff_callback(self, iden, opaque):
++        '''Directly free the opaque object
++
++        This is a coroutine.
++        '''
++        self.log.debug('ff_callback(iden=%d, opaque=...)', iden)
++        return libvirt.virEventInvokeFreeCallback(opaque)
+ 
+     def is_idle(self):
+         '''Returns False if there are leftovers from a connection
+@@ -309,10 +318,10 @@ class virEventAsyncIOImpl(object):
+         .. seealso::
+             https://libvirt.org/html/libvirt-libvirt-event.html#virEventAddHandleFuncFunc
+         '''
+-        self.log.debug('add_handle(fd=%d, event=%d, cb=%r, opaque=%r)',
+-                fd, event, cb, opaque)
+         callback = FDCallback(self, cb, opaque,
+                 descriptor=self.descriptors[fd], event=event)
++        self.log.debug('add_handle(fd=%d, event=%d, cb=..., opaque=...) = %d',
++                fd, event, callback.iden)
+         self.callbacks[callback.iden] = callback
+         self.descriptors[fd].add_handle(callback)
+         return callback.iden
+@@ -339,7 +348,11 @@ class virEventAsyncIOImpl(object):
+             https://libvirt.org/html/libvirt-libvirt-event.html#virEventRemoveHandleFunc
+         '''
+         self.log.debug('remove_handle(watch=%d)', watch)
+-        callback = self.callbacks.pop(watch)
++        try:
++            callback = self.callbacks.pop(watch)
++        except KeyError as err:
++            self.log.warning('remove_handle(): no such handle: %r', err.args[0])
++            raise
+         fd = callback.descriptor.fd
+         assert callback is self.descriptors[fd].remove_handle(watch)
+         if len(self.descriptors[fd].callbacks) == 0:
+@@ -358,9 +371,9 @@ class virEventAsyncIOImpl(object):
+         .. seealso::
+             https://libvirt.org/html/libvirt-libvirt-event.html#virEventAddTimeoutFunc
+         '''
+-        self.log.debug('add_timeout(timeout=%d, cb=%r, opaque=%r)',
+-                timeout, cb, opaque)
+         callback = TimeoutCallback(self, cb, opaque)
++        self.log.debug('add_timeout(timeout=%d, cb=..., opaque=...) = %d',
++                timeout, callback.iden)
+         self.callbacks[callback.iden] = callback
+         callback.update(timeout=timeout)
+         return callback.iden
+-- 
+2.9.5
+

--- a/patches.python/0002-libvirtaio-add-allow-for-moving-callbacks-to-other-e.patch
+++ b/patches.python/0002-libvirtaio-add-allow-for-moving-callbacks-to-other-e.patch
@@ -1,0 +1,152 @@
+From 2df50aedbe569798d9516f6ecfa605898d783c0e Mon Sep 17 00:00:00 2001
+From: Wojtek Porczyk <woju@invisiblethingslab.com>
+Date: Thu, 24 Aug 2017 21:24:50 +0200
+Subject: [PATCH 2/2] libvirtaio: add allow for moving callbacks to other event
+ loop
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+The virEvent implementation is tied to a particular loop. When spinning
+another loop, the callbacks have to be moved to another implementation,
+so they will have a chance to be invoked, should they be scheduled. If
+not, file descriptors will be leaking.
+
+Signed-off-by: Wojtek Porczyk <woju@invisiblethingslab.com>
+---
+ libvirtaio.py | 64 +++++++++++++++++++++++++++++++++++++++++++++++------------
+ 1 file changed, 51 insertions(+), 13 deletions(-)
+
+diff --git a/libvirtaio.py b/libvirtaio.py
+index fc868bd..d161cd1 100644
+--- a/libvirtaio.py
++++ b/libvirtaio.py
+@@ -195,9 +195,10 @@ class FDCallback(Callback):
+         return '<{} iden={} fd={} event={}>'.format(
+             self.__class__.__name__, self.iden, self.descriptor.fd, self.event)
+ 
+-    def update(self, event):
++    def update(self, event=None):
+         '''Update the callback and fix descriptor's watchers'''
+-        self.event = event
++        if event is not None:
++            self.event = event
+         self.descriptor.update()
+ 
+ #
+@@ -238,20 +239,21 @@ class TimeoutCallback(Callback):
+             self.cb(self.iden, self.opaque)
+             self.impl.log.debug('timer %r callback ended', self.iden)
+ 
+-    def update(self, timeout):
++    def update(self, timeout=None):
+         '''Start or the timer, possibly updating timeout'''
+-        self.timeout = timeout
+-
+-        if self.timeout >= 0 and self._task is None:
+-            self.impl.log.debug('timer %r start', self.iden)
+-            self._task = ensure_future(self._timer(),
+-                loop=self.impl.loop)
++        if timeout is not None:
++            self.timeout = timeout
+ 
+-        elif self.timeout < 0 and self._task is not None:
++        if self._task is not None:
+             self.impl.log.debug('timer %r stop', self.iden)
+             self._task.cancel()  # pylint: disable=no-member
+             self._task = None
+ 
++        if self.timeout >= 0:
++            self.impl.log.debug('timer %r start', self.iden)
++            self._task = ensure_future(self._timer(),
++                loop=self.impl.loop)
++
+     def close(self):
+         '''Stop the timer and call ff callback'''
+         super(TimeoutCallback, self).close()
+@@ -274,6 +276,7 @@ class virEventAsyncIOImpl(object):
+         self.callbacks = {}
+         self.descriptors = DescriptorDict(self)
+         self.log = logging.getLogger(self.__class__.__name__)
++        self.pending_tasks = set()
+ 
+     def register(self):
+         '''Register this instance as event loop implementation'''
+@@ -284,9 +287,30 @@ class virEventAsyncIOImpl(object):
+             self._add_timeout, self._update_timeout, self._remove_timeout)
+         return self
+ 
++    def takeover(self, other):
++        '''Take over other implementation, probably registered on another loop
++
++        :param virEventAsyncIOImpl other: other implementation to be taken over
++        '''
++        self.log.warning('%r taking over %r', self, other)
++
++        while other.callbacks:
++            iden, callback = other.callbacks.popitem()
++            self.log.debug('  takeover %d %r', iden, callback)
++            assert callback.iden == iden
++            callback.impl = self
++            self.callbacks[iden] = callback
++
++            if isinstance(callback, FDCallback):
++                fd = callback.descriptor.fd
++                assert callback is other.descriptors[fd].remove_handle(iden)
++                self.descriptors[fd].add_handle(callback)
++
+     def schedule_ff_callback(self, iden, opaque):
+         '''Schedule a ff callback from one of the handles or timers'''
+-        ensure_future(self._ff_callback(iden, opaque), loop=self.loop)
++        fut = ensure_future(self._ff_callback(iden, opaque), loop=self.loop)
++        self.pending_tasks.add(fut)
++        fut.add_done_callback(self.pending_tasks.remove)
+ 
+     @asyncio.coroutine
+     def _ff_callback(self, iden, opaque):
+@@ -297,13 +321,19 @@ class virEventAsyncIOImpl(object):
+         self.log.debug('ff_callback(iden=%d, opaque=...)', iden)
+         return libvirt.virEventInvokeFreeCallback(opaque)
+ 
++    @asyncio.coroutine
++    def drain(self):
++        self.log.debug('drain()')
++        if self.pending_tasks:
++            yield from asyncio.wait(self.pending_tasks, loop=self.loop)
++
+     def is_idle(self):
+         '''Returns False if there are leftovers from a connection
+ 
+         Those may happen if there are sematical problems while closing
+         a connection. For example, not deregistered events before .close().
+         '''
+-        return not self.callbacks
++        return not self.callbacks and not self.pending_tasks
+ 
+     def _add_handle(self, fd, event, cb, opaque):
+         '''Register a callback for monitoring file handle events
+@@ -403,10 +433,18 @@ class virEventAsyncIOImpl(object):
+         callback = self.callbacks.pop(timer)
+         callback.close()
+ 
++
++_current_impl = None
+ def virEventRegisterAsyncIOImpl(loop=None):
+     '''Arrange for libvirt's callbacks to be dispatched via asyncio event loop
+ 
+     The implementation object is returned, but in normal usage it can safely be
+     discarded.
+     '''
+-    return virEventAsyncIOImpl(loop=loop).register()
++    global _current_impl
++    impl = virEventAsyncIOImpl(loop=loop)
++    impl.register()
++    if _current_impl is not None:
++        impl.takeover(_current_impl)
++    _current_impl = impl
++    return impl
+-- 
+2.9.5
+

--- a/patches.python/0003-libvirtaio-cache-the-list-of-callbacks-when-calling.patch
+++ b/patches.python/0003-libvirtaio-cache-the-list-of-callbacks-when-calling.patch
@@ -1,0 +1,43 @@
+From b91cc73076764afa2645bcf345ea75141d53907d Mon Sep 17 00:00:00 2001
+From: Wojtek Porczyk <woju@invisiblethingslab.com>
+Date: Thu, 31 Aug 2017 21:20:40 +0200
+Subject: [PATCH] libvirtaio: cache the list of callbacks when calling
+Organization: Invisible Things Lab
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+When the callback causes something that results in changes wrt
+registered handles, python aborts iteration.
+
+Relevant error message:
+
+    Exception in callback None()
+    handle: <Handle cancelled>
+    Traceback (most recent call last):
+      File "/usr/lib64/python3.5/asyncio/events.py", line 126, in _run
+        self._callback(*self._args)
+      File "/usr/lib64/python3.5/site-packages/libvirtaio.py", line 99, in _handle
+        for callback in self.callbacks.values():
+    RuntimeError: dictionary changed size during iteration
+
+QubesOS/qubes-issues#2805
+Signed-off-by: Wojtek Porczyk <woju@invisiblethingslab.com>
+---
+ libvirtaio.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libvirtaio.py b/libvirtaio.py
+index d161cd1..46923d8 100644
+--- a/libvirtaio.py
++++ b/libvirtaio.py
+@@ -96,7 +96,7 @@ class Descriptor(object):
+ 
+         :param int event: The event (from libvirt's constants) being dispatched
+         '''
+-        for callback in self.callbacks.values():
++        for callback in list(self.callbacks.values()):
+             if callback.event is not None and callback.event & event:
+                 callback.cb(callback.iden, self.fd, event, callback.opaque)
+ 
+-- 
+2.9.4
+


### PR DESCRIPTION
Patches for libvirtaio module, to be included upstream (hopefully in 3.8
version). Those should be updated with the final version (if will be different).

Cc @woju