### PR TITLE
http -> https for source URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ else
 # WIN_PATH is the search path used for configure/make, it should contain msys/mingw binaries and python directory
 
 VERSION := $(shell cat version)
-URL := http://libvirt.org/sources/$(mainturl)libvirt-$(VERSION).tar.xz
+URL := https://libvirt.org/sources/$(mainturl)libvirt-$(VERSION).tar.xz
 
 ifndef SRC_FILE
 ifdef URL

--- a/libvirt-python.spec
+++ b/libvirt-python.spec
@@ -14,7 +14,7 @@ Summary: The libvirt virtualization API python2 binding
 Name: libvirt-python
 Version: %{version}
 Release: 2%{?dist}%{?extra_release}
-Source: http://libvirt.org/sources/python/%{name}-%{version}.tar.gz
+Source: https://libvirt.org/sources/python/%{name}-%{version}.tar.gz
 Url: http://libvirt.org
 Patch0: 0001-libvirtaio-add-more-debug-logging.patch
 Patch1: 0002-libvirtaio-cache-the-list-of-callbacks-when-calling.patch

--- a/libvirt.spec
+++ b/libvirt.spec
@@ -282,7 +282,7 @@ URL: http://libvirt.org/
 %if %(echo %{version} | grep -o \\. | wc -l) == 3
     %define mainturl stable_updates/
 %endif
-Source: http://libvirt.org/sources/%{?mainturl}libvirt-%{version}.tar.xz
+Source: https://libvirt.org/sources/%{?mainturl}libvirt-%{version}.tar.xz
 
 Patch0000: patches.qubes/0001-conf-add-script-attribute-to-disk-specification.patch
 Patch0001: patches.qubes/0002-libxl-use-disk-script-attribute.patch


### PR DESCRIPTION
The server redirects you to https anyway:

    $ curl -IL http://libvirt.org/sources/libvirt-3.3.0.tar.xz
    HTTP/1.1 302 Found
    Date: Tue, 05 Dec 2017 16:49:24 GMT
    Server: Apache/2.2.15 (CentOS)
    Location: https://libvirt.org/sources/libvirt-3.3.0.tar.xz
    Connection: close
    Content-Type: text/html; charset=iso-8859-1

    HTTP/1.1 200 OK
    Date: Tue, 05 Dec 2017 16:49:24 GMT
    Server: Apache/2.2.15 (CentOS)
    Last-Modified: Fri, 05 May 2017 19:46:15 GMT
    ETag: "77b361-d648f8-54ecc246d6fc0"
    Accept-Ranges: bytes
    Content-Length: 14043384
    Connection: close
    Content-Type: application/x-xz

    $ curl -IL http://libvirt.org/sources/python/libvirt-python-3.3.0.tar.gz
    HTTP/1.1 302 Found
    Date: Tue, 05 Dec 2017 16:49:33 GMT
    Server: Apache/2.2.15 (CentOS)
    Location: https://libvirt.org/sources/python/libvirt-python-3.3.0.tar.gz
    Connection: close
    Content-Type: text/html; charset=iso-8859-1

    HTTP/1.1 200 OK
    Date: Tue, 05 Dec 2017 16:49:34 GMT
    Server: Apache/2.2.15 (CentOS)
    Last-Modified: Fri, 05 May 2017 19:48:19 GMT
    ETag: "6a0073-2bd60-54ecc2bd186c0"
    Accept-Ranges: bytes
    Content-Length: 179552
    Connection: close
    Content-Type: application/x-gzip