### PR TITLE
Add support for type=pvh

### DIFF
--- a/libvirt.spec
+++ b/libvirt.spec
@@ -310,6 +310,7 @@ Patch0023: patches.qubes/0024-libxl-add-basic-PVHv2-support.patch
 Patch0024: patches.qubes/0025-libxl-add-support-for-multiple-IP-addresses.patch
 Patch0025: patches.qubes/0026-xenMakeIPList-Don-t-leak-address_array.patch
 Patch0026: patches.qubes/0027-Add-permissive-option-for-PCI-devices.patch
+Patch0027: patches.qubes/0028-libxl-Add-basic-support-for-type-pvh.patch
 
 Requires: libvirt-daemon = %{version}-%{release}
 %if %{with_network}

--- a/patches.qubes/0028-libxl-Add-basic-support-for-type-pvh.patch
+++ b/patches.qubes/0028-libxl-Add-basic-support-for-type-pvh.patch
@@ -1,0 +1,233 @@
+From fbc2d83226f3656e5aadddfe49470bbdc6ef5bc0 Mon Sep 17 00:00:00 2001
+From: Simon Gaiser <simon@invisiblethingslab.com>
+Date: Wed, 24 Jan 2018 04:47:00 +0100
+Subject: [PATCH 27/27] libxl: Add basic support for type=pvh
+
+A bunch of stuff not needed for Qubes is missing (video, input, sound?,
+cpu capabilities handling).
+---
+ docs/schemas/domaincommon.rng  |  2 --
+ src/conf/domain_conf.c         |  7 ++++---
+ src/conf/domain_conf.h         |  2 +-
+ src/libxl/libxl_capabilities.c | 22 ++++++++++++++++++++++
+ src/libxl/libxl_conf.c         | 34 ++++++++++++++++++++++++++++++----
+ src/xenconfig/xen_common.c     |  8 ++++++++
+ 6 files changed, 65 insertions(+), 10 deletions(-)
+
+diff --git a/docs/schemas/domaincommon.rng b/docs/schemas/domaincommon.rng
+index 988bf875c..143597c0a 100644
+--- a/docs/schemas/domaincommon.rng
++++ b/docs/schemas/domaincommon.rng
+@@ -2856,7 +2856,6 @@
+                 <value>qemu</value>
+                 <value>stubdom</value>
+                 <value>stubdom-linux</value>
+-                <value>none</value>
+               </choice>
+             </attribute>
+           </optional>
+@@ -2878,7 +2877,6 @@
+               <value>qemu</value>
+               <value>stubdom</value>
+               <value>stubdom-linux</value>
+-              <value>none</value>
+             </choice>
+           </attribute>
+           <optional>
+diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
+index 39d3dd2a9..63cf90f96 100644
+--- a/src/conf/domain_conf.c
++++ b/src/conf/domain_conf.c
+@@ -119,7 +119,8 @@ VIR_ENUM_IMPL(virDomainOS, VIR_DOMAIN_OSTYPE_LAST,
+               "xen",
+               "linux",
+               "exe",
+-              "uml")
++              "uml",
++              "pvh")
+ 
+ VIR_ENUM_IMPL(virDomainBoot, VIR_DOMAIN_BOOT_LAST,
+               "fd",
+@@ -817,8 +818,7 @@ VIR_ENUM_IMPL(virDomainDiskTray, VIR_DOMAIN_DISK_TRAY_LAST,
+ VIR_ENUM_IMPL(virDomainEmulatorType, VIR_DOMAIN_EMULATOR_TYPE_LAST,
+               "qemu",
+               "stubdom",
+-              "stubdom-linux",
+-              "none");
++              "stubdom-linux");
+ 
+ VIR_ENUM_IMPL(virDomainRNGModel,
+               VIR_DOMAIN_RNG_MODEL_LAST,
+@@ -16798,6 +16798,7 @@ virDomainDefParseBootOptions(virDomainDefPtr def,
+ 
+     if (def->os.type == VIR_DOMAIN_OSTYPE_XEN ||
+         def->os.type == VIR_DOMAIN_OSTYPE_HVM ||
++        def->os.type == VIR_DOMAIN_OSTYPE_PVH ||
+         def->os.type == VIR_DOMAIN_OSTYPE_UML) {
+         xmlNodePtr loader_node;
+ 
+diff --git a/src/conf/domain_conf.h b/src/conf/domain_conf.h
+index 891e3edaa..1918908e2 100644
+--- a/src/conf/domain_conf.h
++++ b/src/conf/domain_conf.h
+@@ -245,6 +245,7 @@ typedef enum {
+     VIR_DOMAIN_OSTYPE_LINUX,
+     VIR_DOMAIN_OSTYPE_EXE,
+     VIR_DOMAIN_OSTYPE_UML,
++    VIR_DOMAIN_OSTYPE_PVH,
+ 
+     VIR_DOMAIN_OSTYPE_LAST
+ } virDomainOSType;
+@@ -1989,7 +1990,6 @@ typedef enum {
+     VIR_DOMAIN_EMULATOR_TYPE_DEFAULT,
+     VIR_DOMAIN_EMULATOR_TYPE_STUBDOM,
+     VIR_DOMAIN_EMULATOR_TYPE_STUBDOM_LINUX,
+-    VIR_DOMAIN_EMULATOR_TYPE_NONE,
+ 
+     VIR_DOMAIN_EMULATOR_TYPE_LAST
+ } virDomainEmulatorType;
+diff --git a/src/libxl/libxl_capabilities.c b/src/libxl/libxl_capabilities.c
+index 839a2ee81..fe0dbcae7 100644
+--- a/src/libxl/libxl_capabilities.c
++++ b/src/libxl/libxl_capabilities.c
+@@ -549,6 +549,28 @@ libxlCapsInitGuests(libxl_ctx *ctx, virCapsPtr caps)
+                                                1) == NULL)
+                 return -1;
+         }
++
++        if (guest_archs[i].hvm) {
++            if ((machines = virCapabilitiesAllocMachines(xen_machines, 1)) == NULL)
++                return -1;
++
++            if ((guest = virCapabilitiesAddGuest(caps,
++                                                 VIR_DOMAIN_OSTYPE_PVH,
++                                                 guest_archs[i].arch,
++                                                 LIBXL_EXECBIN_DIR "/qemu-system-i386",
++                                                 NULL,
++                                                 1,
++                                                 machines)) == NULL) {
++                virCapabilitiesFreeMachines(machines, 1);
++                return -1;
++            }
++            machines = NULL;
++
++            if (virCapabilitiesAddGuestFeature(guest, "apic",
++                                               1,
++                                               0) == NULL)
++                return -1;
++        }
+     }
+ 
+     return 0;
+diff --git a/src/libxl/libxl_conf.c b/src/libxl/libxl_conf.c
+index 300a78877..c8c10604b 100644
+--- a/src/libxl/libxl_conf.c
++++ b/src/libxl/libxl_conf.c
+@@ -173,6 +173,8 @@ libxlMakeDomCreateInfo(libxl_ctx *ctx,
+         case VIR_TRISTATE_SWITCH_LAST:
+             break;
+         }
++    } else if (def->os.type == VIR_DOMAIN_OSTYPE_PVH) {
++        c_info->type = LIBXL_DOMAIN_TYPE_PVH;
+     } else {
+         c_info->type = LIBXL_DOMAIN_TYPE_PV;
+     }
+@@ -338,6 +340,7 @@ libxlMakeDomBuildInfo(virDomainDefPtr def,
+ {
+     libxl_domain_build_info *b_info = &d_config->b_info;
+     int hvm = def->os.type == VIR_DOMAIN_OSTYPE_HVM;
++    bool pvh = def->os.type == VIR_DOMAIN_OSTYPE_PVH;
+     size_t i;
+     size_t nusbdevice = 0;
+ 
+@@ -345,6 +348,8 @@ libxlMakeDomBuildInfo(virDomainDefPtr def,
+ 
+     if (hvm)
+         libxl_domain_build_info_init_type(b_info, LIBXL_DOMAIN_TYPE_HVM);
++    else if (pvh)
++        libxl_domain_build_info_init_type(b_info, LIBXL_DOMAIN_TYPE_PVH);
+     else
+         libxl_domain_build_info_init_type(b_info, LIBXL_DOMAIN_TYPE_PV);
+ 
+@@ -565,8 +570,6 @@ libxlMakeDomBuildInfo(virDomainDefPtr def,
+                 b_info->device_model_version = LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN_TRADITIONAL;
+             else if (def->emulator_type == VIR_DOMAIN_EMULATOR_TYPE_STUBDOM_LINUX)
+                 b_info->device_model_version = LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN;
+-            else if (def->emulator_type == VIR_DOMAIN_EMULATOR_TYPE_NONE)
+-                b_info->device_model_version = LIBXL_DEVICE_MODEL_VERSION_NONE;
+         }
+ 
+         /* In case of stubdom there will be two qemu instances:
+@@ -678,6 +681,29 @@ libxlMakeDomBuildInfo(virDomainDefPtr def,
+             return -1;
+         }
+ #endif
++    } else if (pvh) {
++        libxl_defbool_set(&b_info->u.pvh.apic,
++                          def->features[VIR_DOMAIN_FEATURE_APIC] ==
++                          VIR_TRISTATE_SWITCH_ON);
++
++        libxl_defbool_set(&b_info->u.pvh.nested_hvm, false);
++
++        if (def->os.bootloader) {
++            if (VIR_STRDUP(b_info->u.pvh.bootloader, def->os.bootloader) < 0)
++                return -1;
++        }
++        if (def->os.bootloaderArgs) {
++            if (!(b_info->u.pvh.bootloader_args =
++                  virStringSplit(def->os.bootloaderArgs, " \t\n", 0)))
++                return -1;
++        }
++
++        if (VIR_STRDUP(b_info->cmdline, def->os.cmdline) < 0)
++            return -1;
++        if (VIR_STRDUP(b_info->kernel, def->os.kernel) < 0)
++            return -1;
++        if (VIR_STRDUP(b_info->ramdisk, def->os.initrd) < 0)
++            return -1;
+     } else {
+         /*
+          * For compatibility with the legacy xen toolstack, default to pygrub
+@@ -1134,11 +1160,11 @@ libxlMakeNic(virDomainDefPtr def,
+      * hvm guest").
+      */
+     if (l_nic->model) {
+-        if (def->os.type == VIR_DOMAIN_OSTYPE_XEN &&
++        if (def->os.type != VIR_DOMAIN_OSTYPE_HVM &&
+             STRNEQ(l_nic->model, "netfront")) {
+             virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
+                            _("only model 'netfront' is supported for "
+-                             "Xen PV domains"));
++                             "Xen PV(H) domains"));
+             return -1;
+         }
+         if (VIR_STRDUP(x_nic->model, l_nic->model) < 0)
+diff --git a/src/xenconfig/xen_common.c b/src/xenconfig/xen_common.c
+index dcde30195..6205ed064 100644
+--- a/src/xenconfig/xen_common.c
++++ b/src/xenconfig/xen_common.c
+@@ -581,6 +581,11 @@ xenParseCPUFeatures(virConfPtr conf,
+ 
+             def->clock.timers[def->clock.ntimers - 1] = timer;
+         }
++    } else if (def->os.type == VIR_DOMAIN_OSTYPE_PVH) {
++        if (xenConfigGetBool(conf, "apic", &val, 1) < 0)
++            return -1;
++        else if (val)
++            def->features[VIR_DOMAIN_FEATURE_APIC] = VIR_TRISTATE_SWITCH_ON;
+     } else {
+         if (xenConfigGetBool(conf, "e820_host", &val, 0) < 0) {
+             return -1;
+@@ -1981,6 +1986,9 @@ xenDomainDefAddImplicitInputDevice(virDomainDefPtr def)
+ {
+     virDomainInputBus implicitInputBus = VIR_DOMAIN_INPUT_BUS_XEN;
+ 
++    if (def->os.type == VIR_DOMAIN_OSTYPE_PVH)
++        return 0;
++
+     if (def->os.type == VIR_DOMAIN_OSTYPE_HVM)
+         implicitInputBus = VIR_DOMAIN_INPUT_BUS_PS2;
+ 
+-- 
+2.15.1
+


### PR DESCRIPTION
This replaces the old device_mode_version=none method for configuring
PVHv2 domains.

---

Depends on https://github.com/QubesOS/qubes-vmm-xen/pull/27