### PR TITLE
Support DISTFILES_MIRROR

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -36,6 +36,12 @@ ifdef URL
 endif
 endif
 
+DISTFILES_MIRROR ?=
+
+ifneq ($(DISTFILES_MIRROR),)
+	URL := $(addprefix $(DISTFILES_MIRROR)/,$(SRC_FILE))
+endif
+
 get-sources: $(SRC_FILE)
 
 $(SRC_FILE):


### PR DESCRIPTION
If you plan to put distfiles in the Qubes ftp, I can set directly the url. If not, it allows to set the mirror url.