### PR TITLE
libxl: add ACPI SLIC table support

### DIFF
--- a/libvirt.spec
+++ b/libvirt.spec
@@ -311,6 +311,7 @@ Patch0024: patches.qubes/0025-libxl-add-support-for-multiple-IP-addresses.patch
 Patch0025: patches.qubes/0026-xenMakeIPList-Don-t-leak-address_array.patch
 Patch0026: patches.qubes/0027-Add-permissive-option-for-PCI-devices.patch
 Patch0027: patches.qubes/0028-libxl-Add-basic-support-for-type-pvh.patch
+Patch0028: patches.qubes/0029-libxl-add-acpi-slic-table-support.patch
 
 Requires: libvirt-daemon = %{version}-%{release}
 %if %{with_network}

--- a/patches.qubes/0029-libxl-add-acpi-slic-table-support.patch
+++ b/patches.qubes/0029-libxl-add-acpi-slic-table-support.patch
@@ -1,0 +1,29 @@
+From 6affb1710701af84b0bcbd4f321a9dbd31d8aaee Mon Sep 17 00:00:00 2001
+From: Ivan Kardykov <kardykov@tabit.pro>
+Date: Wed, 28 Aug 2019 16:53:48 +0300
+Subject: [PATCH] libxl: add acpi slic table support
+Signed-off-by: Ivan Kardykov <kardykov@tabit.pro>
+
+---
+ src/libxl/libxl_conf.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/libxl/libxl_conf.c b/src/libxl/libxl_conf.c
+index c8c10604bc..aa9d6f4e1e 100644
+--- a/src/libxl/libxl_conf.c
++++ b/src/libxl/libxl_conf.c
+@@ -485,6 +485,11 @@ libxlMakeDomBuildInfo(virDomainDefPtr def,
+             }
+         }
+ 
++	/* copy SLIC table path to acpi_firmware */
++	if (def->os.slic_table &&
++	    VIR_STRDUP(b_info->u.hvm.acpi_firmware, def->os.slic_table) < 0)
++	    return -1;
++
+         if (def->nsounds > 0) {
+             /*
+              * Use first sound device.  man xl.cfg(5) describes soundhw as
+-- 
+2.20.1
+


### PR DESCRIPTION
Libxl driver did not support setup additional acpi firmware to xen guest. It is necessary to activate OEM Windows installs. This patch allow to define in OS section acpi table param (which supported domain common schema).