### PR TITLE
Redude dependencies of the libvirt-daemon-xen package

### DIFF
--- a/libvirt.spec.in
+++ b/libvirt.spec.in
@@ -953,9 +953,6 @@ Requires: libvirt-daemon-driver-interface = %{epoch}:%{version}-%{release}
 Requires: libvirt-daemon-driver-network = %{epoch}:%{version}-%{release}
 %endif
 Requires: libvirt-daemon-driver-nodedev = %{epoch}:%{version}-%{release}
-Requires: libvirt-daemon-driver-nwfilter = %{epoch}:%{version}-%{release}
-Requires: libvirt-daemon-driver-secret = %{epoch}:%{version}-%{release}
-Requires: libvirt-daemon-driver-storage = %{epoch}:%{version}-%{release}
 Requires: xen
 
 %description daemon-xen


### PR DESCRIPTION
We don't use any of libvirt's firewall, secret, nor storage pools, so
don't install them by default. It's still possible to optionally install
the packages, if anyone would like to use them.

Fixes QubesOS/qubes-issues#6917