### PR TITLE
libxl: fix setting invtsc with Xen 4.14

### DIFF
--- a/0001-conf-add-script-attribute-to-disk-specification.patch
+++ b/0001-conf-add-script-attribute-to-disk-specification.patch
@@ -5,8 +5,6 @@ Subject: [PATCH] conf: add 'script' attribute to disk specification
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 Script to be called to prepare custom device for domain. Done with Xen
 in mind, it maps to libxl_device_disk.script.
@@ -103,5 +101,5 @@ index 6e9da298b4..3f888ba556 100644
      bool diskElementAuth;
      bool diskElementEnc;
 -- 
-2.25.4
+2.35.1
 

--- a/0002-libxl-use-disk-script-attribute.patch
+++ b/0002-libxl-use-disk-script-attribute.patch
@@ -5,8 +5,6 @@ Subject: [PATCH] libxl: use disk 'script' attribute
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 Implement handling of previously introduced <script/> element for disk
 config.
@@ -33,5 +31,5 @@ index 8e63d40376..fe45baed2c 100644
          if (STREQ(driver, "tap") || STREQ(driver, "tap2")) {
              switch (format) {
 -- 
-2.25.4
+2.35.1
 

--- a/0003-libxl-Stubdom-emulator-type.patch
+++ b/0003-libxl-Stubdom-emulator-type.patch
@@ -1,12 +1,10 @@
-From 0baf48162489130085c2db4063b0ad5db0dc720a Mon Sep 17 00:00:00 2001
+From 750218c528023938aa002e14f2b79c18753b1b12 Mon Sep 17 00:00:00 2001
 From: Marek Marczykowski <marmarek@invisiblethingslab.com>
 Date: Sun, 7 Apr 2013 19:48:52 +0200
 Subject: [PATCH] libxl: Stubdom emulator type
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 Xen have feature of having device model in separate domain (called stub
 domain). Add 'type' attribute to 'emulator' element to allow selecting
@@ -15,12 +13,12 @@ such configuration. Emulator path is still used for qemu running in dom0
 
 Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 ---
- docs/formatdomain.html.in     | 17 +++++++++++++++
- docs/schemas/domaincommon.rng | 28 +++++++++++++++++++++++-
- src/conf/domain_conf.c        | 41 +++++++++++++++++++++++++++++++++--
+ docs/formatdomain.html.in     | 17 ++++++++++++++
+ docs/schemas/domaincommon.rng | 28 ++++++++++++++++++++++-
+ src/conf/domain_conf.c        | 42 +++++++++++++++++++++++++++++++++--
  src/conf/domain_conf.h        | 10 +++++++++
- src/libxl/libxl_conf.c        | 17 +++++++++++++++
- 5 files changed, 110 insertions(+), 3 deletions(-)
+ src/libxl/libxl_conf.c        | 17 ++++++++++++++
+ 5 files changed, 111 insertions(+), 3 deletions(-)
 
 diff --git a/docs/formatdomain.html.in b/docs/formatdomain.html.in
 index 6b67a09bb3..684fd7d2fa 100644
@@ -90,7 +88,7 @@ index d0a7a8d055..e2fd697e20 100644
    </define>
    <!--
 diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
-index 0e9db39f83..064ce64b7d 100644
+index 0e9db39f83..b24f8da6c5 100644
 --- a/src/conf/domain_conf.c
 +++ b/src/conf/domain_conf.c
 @@ -1152,6 +1152,11 @@ VIR_ENUM_IMPL(virDomainDiskTray,
@@ -105,15 +103,15 @@ index 0e9db39f83..064ce64b7d 100644
  VIR_ENUM_IMPL(virDomainRNGModel,
                VIR_DOMAIN_RNG_MODEL_LAST,
                "virtio",
-@@ -3538,6 +3538,7 @@ void virDomainDefFree(virDomainDefPtr de
-
+@@ -3527,6 +3532,7 @@ void virDomainDefFree(virDomainDefPtr def)
      VIR_FREE(def->name);
      virBitmapFree(def->cpumask);
-+    VIR_FREE(def->emulator_cmdline);
      VIR_FREE(def->emulator);
++    VIR_FREE(def->emulator_cmdline);
      VIR_FREE(def->description);
      VIR_FREE(def->title);
-@@ -21618,6 +21623,17 @@ virDomainDefParseXML(xmlDocPtr xml,
+     VIR_FREE(def->hyperv_vendor_id);
+@@ -21618,6 +21624,17 @@ virDomainDefParseXML(xmlDocPtr xml,
      if (virDomainDefParseBootOptions(def, ctxt) < 0)
          goto error;
  
@@ -131,7 +129,7 @@ index 0e9db39f83..064ce64b7d 100644
      /* analysis of the disk devices */
      if ((n = virXPathNodeSet("./devices/disk", ctxt, &nodes)) < 0)
          goto error;
-@@ -24157,6 +24173,14 @@ virDomainDefCheckABIStabilityFlags(virDomainDefPtr src,
+@@ -24157,6 +24174,14 @@ virDomainDefCheckABIStabilityFlags(virDomainDefPtr src,
          goto error;
      }
  
@@ -146,7 +144,7 @@ index 0e9db39f83..064ce64b7d 100644
      if (!virDomainDefFeaturesCheckABIStability(src, dst))
          goto error;
  
-@@ -29912,8 +29936,21 @@ virDomainDefFormatInternalSetRootName(virDomainDefPtr def,
+@@ -29912,8 +29937,21 @@ virDomainDefFormatInternalSetRootName(virDomainDefPtr def,
      virBufferAddLit(buf, "<devices>\n");
      virBufferAdjustIndent(buf, 2);
  
@@ -234,5 +232,5 @@ index fe45baed2c..ae2dfae437 100644
              if (def->nserials == 1) {
                  if (libxlMakeChrdevStr(def->serials[0], &b_info->u.hvm.serial) <
 -- 
-2.25.4
+2.35.1
 

--- a/0004-libxl-support-domain-config-modification-in-virDomai.patch
+++ b/0004-libxl-support-domain-config-modification-in-virDomai.patch
@@ -1,4 +1,4 @@
-From 4e8da85237370427c5ff96a4eacab8e661e280a1 Mon Sep 17 00:00:00 2001
+From 09996724fbfd763b74b174dc9ee42cf2b08961fe Mon Sep 17 00:00:00 2001
 From: Marek Marczykowski <marmarek@invisiblethingslab.com>
 Date: Sun, 14 Apr 2013 04:28:00 +0200
 Subject: [PATCH] libxl: support domain config modification in
@@ -6,8 +6,6 @@ Subject: [PATCH] libxl: support domain config modification in
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 ---
@@ -50,5 +48,5 @@ index 4db3c0782e..53120068cb 100644
                                     driver->xmlopt,
                                     VIR_DOMAIN_OBJ_LIST_ADD_LIVE |
 -- 
-2.25.4
+2.35.1
 

--- a/0005-Add-nostrictreset-attribute-to-PCI-host-devices.patch
+++ b/0005-Add-nostrictreset-attribute-to-PCI-host-devices.patch
@@ -1,4 +1,4 @@
-From 0420bc27143cfcc51290896d67a35f96469c4ec3 Mon Sep 17 00:00:00 2001
+From 4b54209512d68c272d6f1033426168d8ba1cd4e6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
  <marmarek@invisiblethingslab.com>
 Date: Sat, 23 May 2015 04:25:01 +0200
@@ -6,8 +6,6 @@ Subject: [PATCH] Add 'nostrictreset' attribute to PCI host devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 This allows to assign PCI device to some VM, even when the device does not
 support any reset method. This may be dangerous in some cases (especially when
@@ -57,10 +55,10 @@ index e2fd697e20..4a48d02e8b 100644
              <element name="source">
                <optional>
 diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
-index 064ce64b7d..6994c7e024 100644
+index b24f8da6c5..717e02fa48 100644
 --- a/src/conf/domain_conf.c
 +++ b/src/conf/domain_conf.c
-@@ -8495,6 +8495,7 @@ virDomainHostdevDefParseXMLSubsys(xmlNodePtr node,
+@@ -8496,6 +8496,7 @@ virDomainHostdevDefParseXMLSubsys(xmlNodePtr node,
      virDomainHostdevSubsysSCSIVHostPtr scsihostsrc = &def->source.subsys.u.scsi_host;
      virDomainHostdevSubsysMediatedDevPtr mdevsrc = &def->source.subsys.u.mdev;
      g_autofree char *managed = NULL;
@@ -68,7 +66,7 @@ index 064ce64b7d..6994c7e024 100644
      g_autofree char *sgio = NULL;
      g_autofree char *rawio = NULL;
      g_autofree char *backendStr = NULL;
-@@ -8510,6 +8511,11 @@ virDomainHostdevDefParseXMLSubsys(xmlNodePtr node,
+@@ -8511,6 +8512,11 @@ virDomainHostdevDefParseXMLSubsys(xmlNodePtr node,
      if ((managed = virXMLPropString(node, "managed")) != NULL)
          ignore_value(virStringParseYesNo(managed, &def->managed));
  
@@ -80,7 +78,7 @@ index 064ce64b7d..6994c7e024 100644
      sgio = virXMLPropString(node, "sgio");
      rawio = virXMLPropString(node, "rawio");
      model = virXMLPropString(node, "model");
-@@ -26400,6 +26406,8 @@ virDomainActualNetDefFormat(virBufferPtr buf,
+@@ -26401,6 +26407,8 @@ virDomainActualNetDefFormat(virBufferPtr buf,
          virDomainHostdevDefPtr hostdef = virDomainNetGetActualHostdev(def);
          if  (hostdef && hostdef->managed)
              virBufferAddLit(buf, " managed='yes'");
@@ -89,7 +87,7 @@ index 064ce64b7d..6994c7e024 100644
      }
      if (def->trustGuestRxFilters)
          virBufferAsprintf(buf, " trustGuestRxFilters='%s'",
-@@ -26588,6 +26596,8 @@ virDomainNetDefFormat(virBufferPtr buf,
+@@ -26589,6 +26597,8 @@ virDomainNetDefFormat(virBufferPtr buf,
      virBufferAsprintf(buf, "<interface type='%s'", typeStr);
      if (hostdef && hostdef->managed)
          virBufferAddLit(buf, " managed='yes'");
@@ -98,7 +96,7 @@ index 064ce64b7d..6994c7e024 100644
      if (def->trustGuestRxFilters)
          virBufferAsprintf(buf, " trustGuestRxFilters='%s'",
                            virTristateBoolTypeToString(def->trustGuestRxFilters));
-@@ -28380,6 +28390,8 @@ virDomainHostdevDefFormat(virBufferPtr buf,
+@@ -28381,6 +28391,8 @@ virDomainHostdevDefFormat(virBufferPtr buf,
      if (def->mode == VIR_DOMAIN_HOSTDEV_MODE_SUBSYS) {
          virBufferAsprintf(buf, " managed='%s'",
                            def->managed ? "yes" : "no");
@@ -196,5 +194,5 @@ index b3322ba61b..16572fc350 100644
  int virPCIDeviceSetUsedBy(virPCIDevice *dev,
                            const char *drv_name,
 -- 
-2.25.4
+2.35.1
 

--- a/0006-libxl-pause-also-stubdomain-if-any-while-pausing-a-d.patch
+++ b/0006-libxl-pause-also-stubdomain-if-any-while-pausing-a-d.patch
@@ -1,4 +1,4 @@
-From cfd90d5551ae133b542f83f17e2601da8eff0a58 Mon Sep 17 00:00:00 2001
+From 05d4a63d53e9e8f709f8bca682e73c9ffb523915 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
  <marmarek@invisiblethingslab.com>
 Date: Wed, 25 Nov 2015 00:48:56 +0100
@@ -6,8 +6,6 @@ Subject: [PATCH] libxl: pause also stubdomain (if any) while pausing a domain
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 Otherwise stubdomain would crash, if host suspend was in effect in the
 meantime.
@@ -79,5 +77,5 @@ index 53120068cb..646cda9f04 100644
          virDomainObjSetState(vm, VIR_DOMAIN_RUNNING,
                               VIR_DOMAIN_RUNNING_UNPAUSED);
 -- 
-2.25.4
+2.35.1
 

--- a/0007-libxl-plug-workaround-for-missing-pcidev-group-assig.patch
+++ b/0007-libxl-plug-workaround-for-missing-pcidev-group-assig.patch
@@ -1,4 +1,4 @@
-From 84815a5316125540c974da5f55cdcd69abc14795 Mon Sep 17 00:00:00 2001
+From 5bee0b3ff6f99815ec1354f5832d50e7d8d644a3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
  <marmarek@invisiblethingslab.com>
 Date: Sat, 28 Nov 2015 18:27:59 +0100
@@ -7,8 +7,6 @@ Subject: [PATCH] libxl: plug workaround for missing pcidev group assignment to
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 From commit in xen tree:
 commit 11d942df114045860a27563418cf5dbd5bcd0402
@@ -49,5 +47,5 @@ index ae2dfae437..a907880886 100644
      return 0;
  }
 -- 
-2.25.4
+2.35.1
 

--- a/0008-libxl-add-linux-stubdom-support.patch
+++ b/0008-libxl-add-linux-stubdom-support.patch
@@ -1,12 +1,10 @@
-From acd6152aa661fd27c5e6af39f9e01ea30baf59c5 Mon Sep 17 00:00:00 2001
+From 36de4b553e6d3bbae5c0a0d42cbf25bd14c93b46 Mon Sep 17 00:00:00 2001
 From: HW42 <hw42@ipsumj.de>
 Date: Sat, 22 Apr 2017 08:56:59 +0200
 Subject: [PATCH] libxl: add linux stubdom support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 ---
@@ -37,7 +35,7 @@ index 4a48d02e8b..7acfcc08aa 100644
            </attribute>
            <empty/>
 diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
-index 6994c7e024..3510e51d2a 100644
+index 717e02fa48..61fdca36bf 100644
 --- a/src/conf/domain_conf.c
 +++ b/src/conf/domain_conf.c
 @@ -1155,7 +1155,8 @@ VIR_ENUM_IMPL(virDomainDiskTray,
@@ -89,5 +87,5 @@ index a907880886..98342bf279 100644
  
          if (def->emulator_cmdline && def->emulator_cmdline[0]) {
 -- 
-2.25.4
+2.35.1
 

--- a/0009-libxl-add-support-for-qubes-graphic-device.patch
+++ b/0009-libxl-add-support-for-qubes-graphic-device.patch
@@ -1,12 +1,10 @@
-From 125fd9bb8ff635fc83194e4d40c0d6384b5eecda Mon Sep 17 00:00:00 2001
+From d095404d4e004328b07f905e5fbf00823f63e437 Mon Sep 17 00:00:00 2001
 From: HW42 <hw42@ipsumj.de>
 Date: Sat, 22 Apr 2017 08:57:58 +0200
 Subject: [PATCH] libxl: add support for qubes graphic device
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 ---
@@ -47,7 +45,7 @@ index 7acfcc08aa..2a5b93651b 100644
            <attribute name="type">
              <value>spice</value>
 diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
-index 3510e51d2a..93f03aa070 100644
+index 61fdca36bf..6edd131b1b 100644
 --- a/src/conf/domain_conf.c
 +++ b/src/conf/domain_conf.c
 @@ -840,6 +840,7 @@ VIR_ENUM_IMPL(virDomainGraphics,
@@ -69,7 +67,7 @@ index 3510e51d2a..93f03aa070 100644
      case VIR_DOMAIN_GRAPHICS_TYPE_SPICE:
          VIR_FREE(def->data.spice.rendernode);
          VIR_FREE(def->data.spice.keymap);
-@@ -14584,6 +14589,30 @@ virDomainGraphicsDefParseXMLDesktop(virDomainGraphicsDefPtr def,
+@@ -14585,6 +14590,30 @@ virDomainGraphicsDefParseXMLDesktop(virDomainGraphicsDefPtr def,
      return 0;
  }
  
@@ -100,7 +98,7 @@ index 3510e51d2a..93f03aa070 100644
  
  static int
  virDomainGraphicsDefParseXMLSpice(virDomainGraphicsDefPtr def,
-@@ -14957,6 +14986,10 @@ virDomainGraphicsDefParseXML(virDomainXMLOptionPtr xmlopt,
+@@ -14958,6 +14987,10 @@ virDomainGraphicsDefParseXML(virDomainXMLOptionPtr xmlopt,
          if (virDomainGraphicsDefParseXMLDesktop(def, node) < 0)
              goto error;
          break;
@@ -111,7 +109,7 @@ index 3510e51d2a..93f03aa070 100644
      case VIR_DOMAIN_GRAPHICS_TYPE_SPICE:
          if (virDomainGraphicsDefParseXMLSpice(def, node, ctxt, flags) < 0)
              goto error;
-@@ -28169,6 +28202,14 @@ virDomainGraphicsDefFormat(virBufferPtr buf,
+@@ -28170,6 +28203,14 @@ virDomainGraphicsDefFormat(virBufferPtr buf,
  
          break;
  
@@ -126,7 +124,7 @@ index 3510e51d2a..93f03aa070 100644
      case VIR_DOMAIN_GRAPHICS_TYPE_SPICE:
          if (!glisten) {
              virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
-@@ -32697,6 +32738,7 @@ virDomainGraphicsDefHasOpenGL(const virDomainDef *def)
+@@ -32698,6 +32739,7 @@ virDomainGraphicsDefHasOpenGL(const virDomainDef *def)
          switch (graphics->type) {
          case VIR_DOMAIN_GRAPHICS_TYPE_VNC:
          case VIR_DOMAIN_GRAPHICS_TYPE_RDP:
@@ -134,7 +132,7 @@ index 3510e51d2a..93f03aa070 100644
          case VIR_DOMAIN_GRAPHICS_TYPE_DESKTOP:
              continue;
          case VIR_DOMAIN_GRAPHICS_TYPE_SDL:
-@@ -32749,6 +32791,7 @@ virDomainGraphicsGetRenderNode(const virDomainGraphicsDef *graphics)
+@@ -32750,6 +32792,7 @@ virDomainGraphicsGetRenderNode(const virDomainGraphicsDef *graphics)
      case VIR_DOMAIN_GRAPHICS_TYPE_SDL:
      case VIR_DOMAIN_GRAPHICS_TYPE_VNC:
      case VIR_DOMAIN_GRAPHICS_TYPE_RDP:
@@ -305,5 +303,5 @@ index a123a8807c..4a72d23dbc 100644
            case VIR_DOMAIN_GRAPHICS_TYPE_SPICE:
            case VIR_DOMAIN_GRAPHICS_TYPE_EGL_HEADLESS:
 -- 
-2.25.4
+2.35.1
 

--- a/0010-libxl-add-support-for-stubdom_mem-option.patch
+++ b/0010-libxl-add-support-for-stubdom_mem-option.patch
@@ -1,12 +1,10 @@
-From 68fa2855a26ea959ff9dd2f729d68852b1b8eddc Mon Sep 17 00:00:00 2001
+From a350f29c1e848a43337e4bcefaeb930168de046c Mon Sep 17 00:00:00 2001
 From: HW42 <hw42@ipsumj.de>
 Date: Sat, 22 Apr 2017 08:59:12 +0200
 Subject: [PATCH] libxl: add support for stubdom_mem option
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 ---
@@ -45,10 +43,10 @@ index 2a5b93651b..3309557d86 100644
          </group>
        </choice>
 diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
-index 93f03aa070..56279f5ffb 100644
+index 6edd131b1b..e63502b79a 100644
 --- a/src/conf/domain_conf.c
 +++ b/src/conf/domain_conf.c
-@@ -21674,6 +21674,17 @@ virDomainDefParseXML(xmlDocPtr xml,
+@@ -21675,6 +21675,17 @@ virDomainDefParseXML(xmlDocPtr xml,
      }
      def->emulator_cmdline = virXPathString("string(./devices/emulator/@cmdline)", ctxt);
  
@@ -66,7 +64,7 @@ index 93f03aa070..56279f5ffb 100644
      /* analysis of the disk devices */
      if ((n = virXPathNodeSet("./devices/disk", ctxt, &nodes)) < 0)
          goto error;
-@@ -24221,6 +24232,14 @@ virDomainDefCheckABIStabilityFlags(virDomainDefPtr src,
+@@ -24222,6 +24233,14 @@ virDomainDefCheckABIStabilityFlags(virDomainDefPtr src,
          goto error;
      }
  
@@ -81,7 +79,7 @@ index 93f03aa070..56279f5ffb 100644
      if (!virDomainDefFeaturesCheckABIStability(src, dst))
          goto error;
  
-@@ -29997,6 +30016,8 @@ virDomainDefFormatInternalSetRootName(virDomainDefPtr def,
+@@ -29998,6 +30017,8 @@ virDomainDefFormatInternalSetRootName(virDomainDefPtr def,
              virBufferAsprintf(buf, " type='%s'",
                                virDomainEmulatorTypeTypeToString(def->emulator_type));
          }
@@ -117,5 +115,5 @@ index e639563261..880afb515a 100644
              if (def->nserials == 1) {
                  if (libxlMakeChrdevStr(def->serials[0], &b_info->u.hvm.serial) <
 -- 
-2.25.4
+2.35.1
 

--- a/0011-Add-permissive-option-for-PCI-devices.patch
+++ b/0011-Add-permissive-option-for-PCI-devices.patch
@@ -1,12 +1,10 @@
-From 2895e2dc9fff331db8d74b4a1d0ee1bba452ae6d Mon Sep 17 00:00:00 2001
+From d330187f0ac552fd9ad2d5356c423c81ff07c332 Mon Sep 17 00:00:00 2001
 From: Simon Gaiser <simon@invisiblethingslab.com>
 Date: Fri, 19 Jan 2018 04:46:01 +0100
 Subject: [PATCH] Add 'permissive' option for PCI devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 By setting the permissive flag the guest access to the PCI config space
 is not filtered. This might be a security risk, but it's required for
@@ -53,10 +51,10 @@ index 3309557d86..bd12c24924 100644
              <element name="source">
                <optional>
 diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
-index 56279f5ffb..619a80cf1c 100644
+index e63502b79a..7f810e10e9 100644
 --- a/src/conf/domain_conf.c
 +++ b/src/conf/domain_conf.c
-@@ -8502,6 +8502,7 @@ virDomainHostdevDefParseXMLSubsys(xmlNodePtr node,
+@@ -8503,6 +8503,7 @@ virDomainHostdevDefParseXMLSubsys(xmlNodePtr node,
      virDomainHostdevSubsysMediatedDevPtr mdevsrc = &def->source.subsys.u.mdev;
      g_autofree char *managed = NULL;
      g_autofree char *nostrictreset = NULL;
@@ -64,7 +62,7 @@ index 56279f5ffb..619a80cf1c 100644
      g_autofree char *sgio = NULL;
      g_autofree char *rawio = NULL;
      g_autofree char *backendStr = NULL;
-@@ -8522,6 +8523,11 @@ virDomainHostdevDefParseXMLSubsys(xmlNodePtr node,
+@@ -8523,6 +8524,11 @@ virDomainHostdevDefParseXMLSubsys(xmlNodePtr node,
              def->nostrictreset = true;
      }
  
@@ -76,7 +74,7 @@ index 56279f5ffb..619a80cf1c 100644
      sgio = virXMLPropString(node, "sgio");
      rawio = virXMLPropString(node, "rawio");
      model = virXMLPropString(node, "model");
-@@ -26461,6 +26467,8 @@ virDomainActualNetDefFormat(virBufferPtr buf,
+@@ -26462,6 +26468,8 @@ virDomainActualNetDefFormat(virBufferPtr buf,
              virBufferAddLit(buf, " managed='yes'");
          if  (hostdef && hostdef->nostrictreset)
              virBufferAddLit(buf, " nostrictreset='yes'");
@@ -85,7 +83,7 @@ index 56279f5ffb..619a80cf1c 100644
      }
      if (def->trustGuestRxFilters)
          virBufferAsprintf(buf, " trustGuestRxFilters='%s'",
-@@ -26651,6 +26659,8 @@ virDomainNetDefFormat(virBufferPtr buf,
+@@ -26652,6 +26660,8 @@ virDomainNetDefFormat(virBufferPtr buf,
          virBufferAddLit(buf, " managed='yes'");
      if (hostdef && hostdef->nostrictreset)
          virBufferAddLit(buf, " nostrictreset='yes'");
@@ -94,7 +92,7 @@ index 56279f5ffb..619a80cf1c 100644
      if (def->trustGuestRxFilters)
          virBufferAsprintf(buf, " trustGuestRxFilters='%s'",
                            virTristateBoolTypeToString(def->trustGuestRxFilters));
-@@ -28453,6 +28463,8 @@ virDomainHostdevDefFormat(virBufferPtr buf,
+@@ -28454,6 +28464,8 @@ virDomainHostdevDefFormat(virBufferPtr buf,
                            def->managed ? "yes" : "no");
          if (def->nostrictreset)
              virBufferAddLit(buf, " nostrictreset='yes'");
@@ -128,5 +126,5 @@ index 880afb515a..6d173a322b 100644
      return 0;
  }
 -- 
-2.25.4
+2.35.1
 

--- a/0012-libxl-use-b_info-acpi-acpi-when-available.patch
+++ b/0012-libxl-use-b_info-acpi-acpi-when-available.patch
@@ -1,4 +1,4 @@
-From b0b394535357ae0e494385b8c25758c25ef7052f Mon Sep 17 00:00:00 2001
+From cb3e80b900ffa1aedb351ff302f411ef37da8e48 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
  <marmarek@invisiblethingslab.com>
 Date: Thu, 10 Sep 2020 06:03:24 +0200
@@ -6,8 +6,6 @@ Subject: [PATCH] libxl: use b_info->{acpi,acpi} when available
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Organization: Invisible Things Lab
-Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
 
 b_info->u.hvm.{acpi,apic} are deprecated. But also, on recent libxl
 version (4.14) the old one seems to be broken. While libxl part should
@@ -252,5 +250,5 @@ index 02c10a9deb..f578ccd3d3 100644
                  "kind": "cirrus"
              },
 -- 
-2.25.4
+2.35.1
 

--- a/0013-libxl-add-support-for-emulator-kernel-and-ramdisk-pa.patch
+++ b/0013-libxl-add-support-for-emulator-kernel-and-ramdisk-pa.patch
@@ -1,13 +1,26 @@
+From 7851be6f2c93855bda943921963682a2a8a1c9bf Mon Sep 17 00:00:00 2001
 From: Dmitry Fedorov <d.fedorov@tabit.pro>
+Date: Wed, 13 Apr 2022 16:19:49 +0200
 Subject: [PATCH] libxl: add support for emulator' kernel and ramdisk path
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Add ability to configure emulator kernel and ramdisk path.
 
 Signed-off-by: Dmitry Fedorov <d.fedorov@tabit.pro>
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ docs/schemas/domaincommon.rng | 20 ++++++++++++++++++++
+ src/conf/domain_conf.c        |  6 ++++++
+ src/conf/domain_conf.h        |  2 ++
+ src/libxl/libxl_conf.c        | 19 +++++++++++++++++++
+ 4 files changed, 47 insertions(+)
 
-diff -bpru libvirt-6.6.0/docs/schemas/domaincommon.rng libvirt-6.6.0.new/docs/schemas/domaincommon.rng
---- libvirt-6.6.0/docs/schemas/domaincommon.rng	2020-12-23 19:05:01.937312919 +0300
-+++ libvirt-6.6.0.new/docs/schemas/domaincommon.rng	2020-12-23 19:01:16.789267904 +0300
+diff --git a/docs/schemas/domaincommon.rng b/docs/schemas/domaincommon.rng
+index bd12c24924..dcdc63e012 100644
+--- a/docs/schemas/domaincommon.rng
++++ b/docs/schemas/domaincommon.rng
 @@ -3502,6 +3502,16 @@
                <ref name="memoryKB"/>
              </attribute>
@@ -42,19 +55,20 @@ diff -bpru libvirt-6.6.0/docs/schemas/domaincommon.rng libvirt-6.6.0.new/docs/sc
            <empty/>
          </group>
        </choice>
-diff -bpru libvirt-6.6.0/src/conf/domain_conf.c libvirt-6.6.0.new/src/conf/domain_conf.c
---- libvirt-6.6.0/src/conf/domain_conf.c	2020-12-23 19:05:01.941312938 +0300
-+++ libvirt-6.6.0.new/src/conf/domain_conf.c	2020-12-23 18:59:44.848841163 +0300
-@@ -3539,6 +3539,8 @@ void virDomainDefFree(virDomainDefPtr de
-     VIR_FREE(def->name);
+diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
+index 7f810e10e9..6c604338a9 100644
+--- a/src/conf/domain_conf.c
++++ b/src/conf/domain_conf.c
+@@ -3539,6 +3539,8 @@ void virDomainDefFree(virDomainDefPtr def)
      virBitmapFree(def->cpumask);
+     VIR_FREE(def->emulator);
      VIR_FREE(def->emulator_cmdline);
 +    VIR_FREE(def->emulator_kernel);
 +    VIR_FREE(def->emulator_ramdisk);
-     VIR_FREE(def->emulator);
      VIR_FREE(def->description);
      VIR_FREE(def->title);
-@@ -21711,6 +21711,8 @@ virDomainDefParseXML(xmlDocPtr xml,
+     VIR_FREE(def->hyperv_vendor_id);
+@@ -21680,6 +21682,8 @@ virDomainDefParseXML(xmlDocPtr xml,
          }
      }
      def->emulator_cmdline = virXPathString("string(./devices/emulator/@cmdline)", ctxt);
@@ -63,7 +77,7 @@ diff -bpru libvirt-6.6.0/src/conf/domain_conf.c libvirt-6.6.0.new/src/conf/domai
  
      n = virXPathULong("string(./devices/emulator/@memory)",
                        ctxt,
-@@ -30063,6 +30065,8 @@ virDomainDefFormatInternalSetRootName(vi
+@@ -30032,6 +30036,8 @@ virDomainDefFormatInternalSetRootName(virDomainDefPtr def,
          if (def->emulator_memory != 0)
              virBufferAsprintf(buf, " memory='%lu'", def->emulator_memory);
          virBufferEscapeString(buf, " cmdline='%s'", def->emulator_cmdline);
@@ -72,10 +86,11 @@ diff -bpru libvirt-6.6.0/src/conf/domain_conf.c libvirt-6.6.0.new/src/conf/domai
          if (!def->emulator) {
              virBufferAddLit(buf, "/>\n");
          } else {
-diff -bpru libvirt-6.6.0/src/conf/domain_conf.h libvirt-6.6.0.new/src/conf/domain_conf.h
---- libvirt-6.6.0/src/conf/domain_conf.h	2020-12-23 19:05:01.963313040 +0300
-+++ libvirt-6.6.0.new/src/conf/domain_conf.h	2020-12-23 18:59:44.817841019 +0300
-@@ -2570,6 +2570,8 @@ struct _virDomainDef {
+diff --git a/src/conf/domain_conf.h b/src/conf/domain_conf.h
+index 5d55759086..71e79db091 100644
+--- a/src/conf/domain_conf.h
++++ b/src/conf/domain_conf.h
+@@ -2566,6 +2566,8 @@ struct _virDomainDef {
      char *emulator;
      virDomainEmulatorType emulator_type;
      char *emulator_cmdline;
@@ -84,10 +99,11 @@ diff -bpru libvirt-6.6.0/src/conf/domain_conf.h libvirt-6.6.0.new/src/conf/domai
      unsigned long emulator_memory;
      /* Most {caps_,hyperv_,kvm_,}feature options utilize a virTristateSwitch
       * to handle support. A few assign specific data values to the option.
-diff -bpru libvirt-6.6.0/src/libxl/libxl_conf.c libvirt-6.6.0.new/src/libxl/libxl_conf.c
---- libvirt-6.6.0/src/libxl/libxl_conf.c	2021-06-20 15:20:01.803415062 +0300
-+++ libvirt-6.6.0.new/src/libxl/libxl_conf.c	2021-06-20 15:05:42.078037448 +0300
-@@ -629,6 +629,25 @@ libxlMakeDomBuildInfo(virDomainDefPtr de
+diff --git a/src/libxl/libxl_conf.c b/src/libxl/libxl_conf.c
+index 14d97e34c5..7e9adf57c1 100644
+--- a/src/libxl/libxl_conf.c
++++ b/src/libxl/libxl_conf.c
+@@ -629,6 +629,25 @@ libxlMakeDomBuildInfo(virDomainDefPtr def,
              }
          }
  
@@ -113,3 +129,6 @@ diff -bpru libvirt-6.6.0/src/libxl/libxl_conf.c libvirt-6.6.0.new/src/libxl/libx
          if (def->emulator_memory != 0)
              b_info->stubdomain_memkb = def->emulator_memory;
  
+-- 
+2.35.1
+

--- a/0014-libxl-Fix-setting-invtsc-in-Xen-4.14.patch
+++ b/0014-libxl-Fix-setting-invtsc-in-Xen-4.14.patch
@@ -1,0 +1,39 @@
+From e55f4e15ea429894a5e09191428d2598ad3bfb8f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 13 Apr 2022 15:58:50 +0200
+Subject: [PATCH] libxl: Fix setting invtsc in Xen 4.14
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Xen 4.14 overrides invtsc CPUID field with disable_migrate setting.
+In later versions it has separate itsc config value and also should not
+override explicit value anymore.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ src/libxl/libxl_conf.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/libxl/libxl_conf.c b/src/libxl/libxl_conf.c
+index 7e9adf57c1..128f2b31fd 100644
+--- a/src/libxl/libxl_conf.c
++++ b/src/libxl/libxl_conf.c
+@@ -462,6 +462,13 @@ libxlMakeDomBuildInfo(virDomainDefPtr def,
+                                 hasHwVirt = true;
+                                 continue;
+                             }
++                            if (STREQ(def->cpu->features[i].name, "invtsc")) {
++                                /* Xen overrides invtsc with the value of
++                                 * disable_migrate - set
++                                 * disable_migrate to have invtsc enabled.
++                                 */
++                                libxl_defbool_set(&b_info->disable_migrate, true);
++                            }
+ 
+                             g_snprintf(xlCPU,
+                                        sizeof(xlCPU),
+-- 
+2.35.1
+

--- a/libvirt.spec.in
+++ b/libvirt.spec.in
@@ -292,6 +292,7 @@ Patch0010: 0010-libxl-add-support-for-stubdom_mem-option.patch
 Patch0011: 0011-Add-permissive-option-for-PCI-devices.patch
 Patch0012: 0012-libxl-use-b_info-acpi-acpi-when-available.patch
 Patch0013: 0013-libxl-add-support-for-emulator-kernel-and-ramdisk-pa.patch
+Patch0014: 0014-libxl-Fix-setting-invtsc-in-Xen-4.14.patch
 
 Requires: libvirt-daemon = %{epoch}:%{version}-%{release}
 %if %{with_network}

--- a/libvirt.spec.in
+++ b/libvirt.spec.in
@@ -291,7 +291,7 @@ Patch0009: 0009-libxl-add-support-for-qubes-graphic-device.patch
 Patch0010: 0010-libxl-add-support-for-stubdom_mem-option.patch
 Patch0011: 0011-Add-permissive-option-for-PCI-devices.patch
 Patch0012: 0012-libxl-use-b_info-acpi-acpi-when-available.patch
-Patch0013: 0013-libxl-stubdom-add-kernel-ramdisk-options.patch
+Patch0013: 0013-libxl-add-support-for-emulator-kernel-and-ramdisk-pa.patch
 
 Requires: libvirt-daemon = %{epoch}:%{version}-%{release}
 %if %{with_network}


### PR DESCRIPTION
Xen 4.14 will override CPUID policy setting with disable_migrate flag. 
That's the only thing that disable_migrate flag does. So, let libvirt set
disable_migrate flag when requested to set invtsc.

QubesOS/qubes-issues#7404